### PR TITLE
Quit if any conversion fails

### DIFF
--- a/mdtopdf.bash
+++ b/mdtopdf.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cmd='pandoc -s -f markdown+smart
          --pdf-engine xelatex
          --filter /graphviz.py 


### PR DESCRIPTION
Currently, even if the pandoc command fails in the loop, the shell script goes on running.  This is not what we want.  Instead, we want the pre-commit hook terminates and errors if any conversion fails.