### PR TITLE
Reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,22 @@ FROM python:3.8-slim-buster
 # requires GraphViz and its Python binding, which depends on
 # libgrpahviz-dev.
 RUN apt-get -qq update && \
-	apt-get -qq install -y texlive-xetex graphviz libgraphviz-dev curl build-essential && \
-	apt-get -qq clean && \
-	apt-get -qq autoremove && \
-	rm -rf /var/lib/apt/lists/* /tmp/*
+        apt-get -qq install -y texlive-xetex graphviz libgraphviz-dev curl build-essential && \
+        apt-get -qq clean && \
+        apt-get -qq autoremove && \
+        rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Install the most recent version of Pandoc.
 RUN curl -s -L https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH=/usr/local/pandoc-2.9.2.1/bin:$PATH
 
 RUN python -m pip --quiet install --upgrade pip && \
-	python -m pip --quiet install pygraphviz pandocfilters
+        python -m pip --quiet install pygraphviz pandocfilters
 
 # Install CJK fonts.
 RUN curl -s -L https://noto-website-2.storage.googleapis.com/pkgs/NotoSansSC.zip > f.zip && \
-	unzip -qq f.zip && \
-	mv *.otf  /usr/local/share/fonts/ && \
+        unzip -qq f.zip && \
+        mv *.otf  /usr/local/share/fonts/ && \
         rm f.zip
 
 COPY graphviz.py /graphviz.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # The GraphViz filter for Pandoc is in Python.
-FROM python:3.8
+FROM python:3.8-slim-buster
 
 # Pandoc calls XeLaTex to generate PDF files.  Our Pandoc filter
 # requires GraphViz and its Python binding, which depends on
 # libgrpahviz-dev.
 RUN apt-get -qq update && \
-	apt-get -qq install -y texlive-xetex graphviz libgraphviz-dev && \
+	apt-get -qq install -y texlive-xetex graphviz libgraphviz-dev curl build-essential && \
 	apt-get -qq clean && \
 	apt-get -qq autoremove && \
 	rm -rf /var/lib/apt/lists/* /tmp/*
@@ -20,7 +20,8 @@ RUN python -m pip --quiet install --upgrade pip && \
 # Install CJK fonts.
 RUN curl -s -L https://noto-website-2.storage.googleapis.com/pkgs/NotoSansSC.zip > f.zip && \
 	unzip -qq f.zip && \
-	mv *.otf  /usr/local/share/fonts/
+	mv *.otf  /usr/local/share/fonts/ && \
+        rm f.zip
 
 COPY graphviz.py /graphviz.py
 COPY mdtopdf.bash /mdtopdf.bash


### PR DESCRIPTION
Follow suggestions in https://github.com/wangkuiyi/pandoc-with-graphviz-filter/commit/ff8216f4c7243e175938f0c57abbbf80fcf9e583#diff-3254677a7917c6c01f55212f86c57fbfR2  to reduce Docker image size from 1.85GB to 1.27GB.